### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
         <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
-            <%= link_to image_tag(item.image, class: "item-img"), "#" %>
+            <%= link_to image_tag(item.image, class: "item-img"), item_path(item.id) %>
 
             <%# 商品が売れていればsold outを表示しましょう %>
             <%# 商品購入機能実装後に実装 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
@@ -35,7 +34,6 @@
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.explanation %></span>
@@ -103,9 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,111 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# 商品購入機能実装後に実装 %>
+      <%# <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div> %>
+      <%# //商品購入機能実装後に実装 %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= "¥ #{@item.price}" %>
+      </span>
+      <span class="item-postage">
+        <%= @item.delivery_charge.name %>
+      </span>
+    </div>
+
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% elsif user_signed_in? && current_user.id != @item.user_id%>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+    <div class="item-explain-box">
+      <span><%= @item.explanation %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.condition.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.delivery_charge.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
+  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+</div>
+
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# What
- itemsコントローラーのshowアクションを定義
- routes.rbにitemsコントローラーに定義したshowアクションのルーティングを設定
- items/index.html.erbに詳細ページ(showアクション)へのパスを記述
- 商品詳細ページビューファイル(items/show.html.erb)の実装

# Why
商品詳細表示機能実装のため

# Gyazo URL
- ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
- ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
- 商品出品時に登録した情報が見られるようになっていること
- 画像が表示されており、画像がリンク切れなどになっていないこと
  https://gyazo.com/7ee481eb08cb93834226795a6b0eeea4

- ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
  https://gyazo.com/ede57b20329d80bed1331348028d582c

- ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
  https://gyazo.com/53fcce990daefd4ce439687b8840fc86

- 商品購入機能実装後の実装予定
  - ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
  - 売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
