### PR TITLE
投稿画像プレビュー機能の実装

### DIFF
--- a/app/assets/stylesheets/items/new.css
+++ b/app/assets/stylesheets/items/new.css
@@ -89,6 +89,12 @@
   margin-bottom: 15px;
 }
 
+.prev_img {
+  height: 100px;
+  width: 130px;
+  object-fit: contain;
+}
+
 /* /出品画像 */
 
 /* 商品名と商品説明 */

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,7 @@ require("@rails/activestorage").start()
 require("channels")
 require("../commission")
 require("../card")
-
+require('./preview')
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,0 +1,30 @@
+if (document.URL.match( /new/ ) || document.URL.match( /edit/ )) {
+  document.addEventListener('DOMContentLoaded', function(){
+    const ImageList = document.getElementById('image-list');
+
+    const createImageHTML = (blob) => {
+      const imageElement = document.createElement('div');
+
+      const blobImage = document.createElement('img');
+      blobImage.setAttribute('src', blob);
+
+      const prevImage = document.getElementById('image-list');
+      blobImage.classList.add('prev_img');
+
+      imageElement.appendChild(blobImage);
+      ImageList.appendChild(imageElement);
+    };
+
+    document.getElementById('item-image').addEventListener('change', function(e){
+      const imageContent = document.querySelector('prev_img');
+      if (imageContent){
+        imageContent.remove();
+      }
+
+      const file = e.target.files[0];
+      const blob = window.URL.createObjectURL(file);
+
+      createImageHTML(blob);
+    });
+  });
+}

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -22,6 +22,7 @@ app/assets/stylesheets/items/new.css %>
         </p>
         <%= f.file_field :image, id:"item-image" %>
       </div>
+      <div id="image-list"></div>
     </div>
 
     <div class="new-items">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -20,6 +20,7 @@
         </p>
         <%= f.file_field :image, id:"item-image" %>
       </div>
+      <div id="image-list"></div>
     </div>
 
     <div class="new-items">


### PR DESCRIPTION
# What
- javascript/packs/preview.jsの作成
- items/new.html.erbにpreview.jsで取得する要素を記述。
- items/edit.html.erbにpreview.jsで取得する要素を記述。

# Why
投稿画像プレビュー機能実装のため。